### PR TITLE
Add plumbing for enabledTests and enabledSpecifications configuration

### DIFF
--- a/src/main/java/io/github/xmppinteroptesting/bambootask/ExecuteInteropTestsTask.java
+++ b/src/main/java/io/github/xmppinteroptesting/bambootask/ExecuteInteropTestsTask.java
@@ -48,6 +48,8 @@ public class ExecuteInteropTestsTask implements TaskType
             final String accountPassword = config.get(ADMIN_ACCOUNT_PASSWORD);
             final String disabledTests = config.get(DISABLED_TESTS);
             final String disabledSpecifications = config.get(DISABLED_SPECIFICATIONS);
+            final String enabledTests = config.get(ENABLED_TESTS);
+            final String enabledSpecifications = config.get(ENABLED_SPECIFICATIONS);
             final String sintExecutable = config.get(SINTEXECUTABLE);
             final String buildJdk = config.get(BUILDJDK);
 
@@ -81,10 +83,16 @@ public class ExecuteInteropTestsTask implements TaskType
                 command.add("-Dsinttest.adminAccountPassword=" + accountPassword);
             }
             if (!StringUtils.isBlank(disabledTests)) {
-                command.add("-Dsinttest.disabledTests=" + accountUsername);
+                command.add("-Dsinttest.disabledTests=" + disabledTests);
             }
             if (!StringUtils.isBlank(disabledSpecifications)) {
-                command.add("-Dsinttest.disabledSpecifications=" + accountUsername);
+                command.add("-Dsinttest.disabledSpecifications=" + disabledSpecifications);
+            }
+            if (!StringUtils.isBlank(enabledTests)) {
+                command.add("-Dsinttest.enabledTests=" + enabledTests);
+            }
+            if (!StringUtils.isBlank(enabledSpecifications)) {
+                command.add("-Dsinttest.enabledSpecifications=" + enabledSpecifications);
             }
             command.add("-Dsinttest.securityMode=disabled");
             command.add("-Dsinttest.enabledConnections=tcp");

--- a/src/main/java/io/github/xmppinteroptesting/bambootask/ExecuteInteropTestsTaskConfigurator.java
+++ b/src/main/java/io/github/xmppinteroptesting/bambootask/ExecuteInteropTestsTaskConfigurator.java
@@ -42,6 +42,8 @@ public class ExecuteInteropTestsTaskConfigurator extends AbstractTaskConfigurato
         config.put(ADMIN_ACCOUNT_PASSWORD, params.getString(ADMIN_ACCOUNT_PASSWORD));
         config.put(DISABLED_TESTS, params.getString(DISABLED_TESTS));
         config.put(DISABLED_SPECIFICATIONS, params.getString(DISABLED_SPECIFICATIONS));
+        config.put(ENABLED_TESTS, params.getString(ENABLED_TESTS));
+        config.put(ENABLED_SPECIFICATIONS, params.getString(ENABLED_SPECIFICATIONS));
         config.put(SINTEXECUTABLE, params.getString(SINTEXECUTABLE));
         config.put(BUILDJDK, params.getString(BUILDJDK));
         return config;
@@ -89,6 +91,8 @@ public class ExecuteInteropTestsTaskConfigurator extends AbstractTaskConfigurato
         context.put(ADMIN_ACCOUNT_PASSWORD, taskDefinition.getConfiguration().get(ADMIN_ACCOUNT_PASSWORD));
         context.put(DISABLED_TESTS, taskDefinition.getConfiguration().get(DISABLED_TESTS));
         context.put(DISABLED_SPECIFICATIONS, taskDefinition.getConfiguration().get(DISABLED_SPECIFICATIONS));
+        context.put(ENABLED_TESTS, taskDefinition.getConfiguration().get(ENABLED_TESTS));
+        context.put(ENABLED_SPECIFICATIONS, taskDefinition.getConfiguration().get(ENABLED_SPECIFICATIONS));
         context.put(SINTEXECUTABLE, taskDefinition.getConfiguration().get(SINTEXECUTABLE));
         context.put(BUILDJDK, taskDefinition.getConfiguration().get(BUILDJDK));
 

--- a/src/main/java/io/github/xmppinteroptesting/bambootask/ExecuteInteropTestsTaskConstants.java
+++ b/src/main/java/io/github/xmppinteroptesting/bambootask/ExecuteInteropTestsTaskConstants.java
@@ -9,6 +9,8 @@ public class ExecuteInteropTestsTaskConstants
     public static final String ADMIN_ACCOUNT_PASSWORD = "adminAccountPassword";
     public static final String DISABLED_TESTS = "disabledTests";
     public static final String DISABLED_SPECIFICATIONS = "disabledSpecifications";
+    public static final String ENABLED_TESTS = "enabledTests";
+    public static final String ENABLED_SPECIFICATIONS = "enabledSpecifications";
     public static final String SINTEXECUTABLE = "sintexecutable";
     public static final String BUILDJDK = "buildJdk";
 }


### PR DESCRIPTION
Whilst I haven't used or seen this plugin, this follows the existing patterns of config to add enabledTests and enabledSpecifications.

Also fixes a couple of other variables that were miswired.