### PR TITLE
Denote release v1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.xmppinteroptesting</groupId>
     <artifactId>bambootask</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.5.0</version>
 
     <organization>
         <name>XMPP Interop Testing</name>


### PR DESCRIPTION
Note that this project does not include the tests themselves. Instead, it provides infrastructure for an administrator to provide a Bamboo Executable that provides the tests.

Download the latest release of the Smack SINT Server Extensions project, which should be a JAR-file. This is the file that will be added as a Bamboo Executable capability.

The version number of this release mimics that of a release of the Smack SINT Server Extensions project, in which functionality is exposed that's now also available in this Bamboo project (enabling specific tests or specifications).