### PR TITLE
Add config option for fail-on-impossible-test

### DIFF
--- a/src/main/java/io/github/xmppinteroptesting/bambootask/ExecuteInteropTestsTask.java
+++ b/src/main/java/io/github/xmppinteroptesting/bambootask/ExecuteInteropTestsTask.java
@@ -56,6 +56,7 @@ public class ExecuteInteropTestsTask implements TaskType
             final String disabledSpecifications = config.get(DISABLED_SPECIFICATIONS);
             final String enabledTests = config.get(ENABLED_TESTS);
             final String enabledSpecifications = config.get(ENABLED_SPECIFICATIONS);
+            final String failOnImpossibleTest = config.get(FAIL_ON_IMPOSSIBLE_TEST);
             final String sintExecutable = config.get(SINTEXECUTABLE);
             final String buildJdk = config.get(BUILDJDK);
 
@@ -117,6 +118,9 @@ public class ExecuteInteropTestsTask implements TaskType
             }
             if (!StringUtils.isBlank(enabledSpecifications)) {
                 command.add("-Dsinttest.enabledSpecifications=" + enabledSpecifications);
+            }
+            if (!StringUtils.isBlank(failOnImpossibleTest)) {
+                command.add("-Dsinttest.failOnImpossibleTest=" + Boolean.parseBoolean(failOnImpossibleTest));
             }
             command.add("-Dsinttest.securityMode=disabled");
             command.add("-Dsinttest.enabledConnections=tcp");

--- a/src/main/java/io/github/xmppinteroptesting/bambootask/ExecuteInteropTestsTaskConstants.java
+++ b/src/main/java/io/github/xmppinteroptesting/bambootask/ExecuteInteropTestsTaskConstants.java
@@ -17,6 +17,7 @@ public class ExecuteInteropTestsTaskConstants
     public static final String DISABLED_SPECIFICATIONS = "disabledSpecifications";
     public static final String ENABLED_TESTS = "enabledTests";
     public static final String ENABLED_SPECIFICATIONS = "enabledSpecifications";
+    public static final String FAIL_ON_IMPOSSIBLE_TEST = "failOnImpossibleTest";
     public static final String SINTEXECUTABLE = "sintexecutable";
     public static final String BUILDJDK = "buildJdk";
 }

--- a/src/main/resources/editExecuteInteropTestsTask.ftl
+++ b/src/main/resources/editExecuteInteropTestsTask.ftl
@@ -15,3 +15,4 @@
 [@ww.textfield labelKey="xmppinteroptesting.enabledSpecifications" name="enabledSpecifications" required='false'/]
 [@ww.textfield labelKey="xmppinteroptesting.disabledTests" name="disabledTests" required='false'/]
 [@ww.textfield labelKey="xmppinteroptesting.disabledSpecifications" name="disabledSpecifications" required='false'/]
+[@ww.checkbox labelKey="xmppinteroptesting.failOnImpossibleTest" name="failOnImpossibleTest" required='false'/]

--- a/src/main/resources/english.properties
+++ b/src/main/resources/english.properties
@@ -13,6 +13,7 @@ xmppinteroptesting.enabledTests=A comma-separated list of tests that are to be i
 xmppinteroptesting.enabledSpecifications=A comma-separated list of specifications (not case-sensitive) that are to be included. All specifications are included by default.
 xmppinteroptesting.disabledTests=A comma-separated list of tests that are to be skipped.
 xmppinteroptesting.disabledSpecifications=A comma-separated list of specifications (not case-sensitive) that are to be skipped.
+xmppinteroptesting.failOnImpossibleTest=Fails the test run if any configured tests were impossible to execute.
 xmppinteroptesting.error.empty=This cannot be empty. Please provide a value.
 xmppinteroptesting.error.nan=This value needs to be a number.
 xmppinteroptesting.error.negative=This value needs to be a positive number.


### PR DESCRIPTION
Test may be impossible to run, for example, because the server that's being tested does not support a particular feature.

It is not unreasonable for users to assume that, upon a successful test execution result, all tests have passed. In the case of 'impossible' tests, this isn't necessarily the case: some test might not have executed at all.

Especially in scenarios where users have configured the test run to enable a specific subset of the tests (through configuration such as enabledTests and enabledSpecifications) it may be desirable to hard fail when a test was impossible to execute. This enforces that a test run was strictly successful in all tests it was configured to execute.

fixes #11